### PR TITLE
Feature/multiple instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,6 @@ If you are using `https://` for your website
 
     render "active_admin/geocomplete", :form => f, :https => true
 
+If you want to use multiple geocomplete instances on the one page (i.e. for nested forms), you need to pass through a `map_id` (defaults to "map_canvas")
 
+    render "active_admin/geocomplete", :form => f, :map_id => "my_map"

--- a/app/assets/javascripts/active_admin/geocomplete.js
+++ b/app/assets/javascripts/active_admin/geocomplete.js
@@ -17,15 +17,16 @@ $(document).ready(function(){
 
     /////////////////////////////////////////////////////////
     $find_field.bind("geocode:result", function(event, result){
-      // console.log("result");
-      // console.log(result.address_components);
-      var full_address = $("input[data-geo=formatted_address]", $wrapper).val();
+      wrapper = $(event.target).closest('.aageocomplete_wrapper')
+      var full_address = $("input[data-geo=formatted_address]", wrapper).val();
     });
 
     /////////////////////////////////////////////////////////
     $find_field.bind("geocode:dragged", function(event, latLng){
-      $("input[data-geo=lat]", $wrapper).val(latLng.lat());
-      $("input[data-geo=lng]", $wrapper).val(latLng.lng());
+      wrapper = $(event.target).closest('.aageocomplete_wrapper')
+
+      $("input[data-geo=lat]", wrapper).val(latLng.lat());
+      $("input[data-geo=lng]", wrapper).val(latLng.lng());
       // $find_field.geocomplete("find", latLng.lat() + ',' + latLng.lng()); // so we get address updated on drag as well
     });
     /////////////////////////////////////////////////////////

--- a/app/assets/javascripts/active_admin/geocomplete.js
+++ b/app/assets/javascripts/active_admin/geocomplete.js
@@ -1,34 +1,37 @@
 $(document).ready(function(){
 
-  $find_field = $(".find_location_input");
+  $(".aageocomplete_wrapper").each(function() {
+    $wrapper = $(this);
+    $find_field = $(".find_location_input", $wrapper);
+    $map_canvas = $(".map_canvas", $wrapper);
 
-  //setup
-  $find_field.geocomplete({
-    map: ".map_canvas",
-    markerOptions: {
-      draggable: true
-    },
-    details: "form ol",
-    detailsAttribute: "data-geo"
+    //setup
+    $find_field.geocomplete({
+      map: $map_canvas,
+      markerOptions: {
+        draggable: true
+      },
+      details: $wrapper,
+      detailsAttribute: "data-geo"
+    });
+
+    /////////////////////////////////////////////////////////
+    $find_field.bind("geocode:result", function(event, result){
+      // console.log("result");
+      // console.log(result.address_components);
+      var full_address = $("input[data-geo=formatted_address]", $wrapper).val();
+    });
+
+    /////////////////////////////////////////////////////////
+    $find_field.bind("geocode:dragged", function(event, latLng){
+      $("input[data-geo=lat]", $wrapper).val(latLng.lat());
+      $("input[data-geo=lng]", $wrapper).val(latLng.lng());
+      // $find_field.geocomplete("find", latLng.lat() + ',' + latLng.lng()); // so we get address updated on drag as well
+    });
+    /////////////////////////////////////////////////////////
+
+    // let's use lat/long to display an existing location
+    var location = $("input[data-geo=lat]", $wrapper).val() + ',' + $("input[data-geo=lng]", $wrapper).val();
+    $find_field.geocomplete("find", location);
   });
-
-  /////////////////////////////////////////////////////////
-  $find_field.bind("geocode:result", function(event, result){
-    // console.log("result");
-    // console.log(result.address_components);
-    var full_address = $("input[data-geo=formatted_address]").val();
-  });
-
-  /////////////////////////////////////////////////////////
-  $find_field.bind("geocode:dragged", function(event, latLng){
-    $("input[data-geo=lat]").val(latLng.lat());
-    $("input[data-geo=lng]").val(latLng.lng());
-    // $find_field.geocomplete("find", latLng.lat() + ',' + latLng.lng()); // so we get address updated on drag as well 
-  });
-  /////////////////////////////////////////////////////////
-
-  // let's use lat/long to display an existing location
-  var location = $("input[data-geo=lat]").val() + ',' + $("input[data-geo=lng]").val();
-  $find_field.geocomplete("find", location);
-
 });

--- a/app/views/active_admin/_geocomplete.html.erb
+++ b/app/views/active_admin/_geocomplete.html.erb
@@ -6,27 +6,25 @@
  map_id = "map_canvas" if map_id.nil?
  %>
 
-<div class="aageocomplete_wrapper">
-  <% if https %>
-   <script src="https://maps.googleapis.com/maps/api/js?sensor=false&amp;libraries=places"></script>
-  <% else %>
-    <script src="http://maps.googleapis.com/maps/api/js?sensor=false&amp;libraries=places"></script>
-  <% end %>
+<% if https %>
+ <script src="https://maps.googleapis.com/maps/api/js?sensor=false&amp;libraries=places"></script>
+<% else %>
+  <script src="http://maps.googleapis.com/maps/api/js?sensor=false&amp;libraries=places"></script>
+<% end %>
 
-  <%= form.inputs "Location" do %>
-  	<% if address != false%>
-    	<%= form.input address, :as => :geocomplete %>
-    <% else %>
-	    <li class="input optional">
-	      <label class="label">Address</label>
-	      <input type="text" class="find_location_input">
-	    </li>
-    <% end %>
-    <li class="input optional" id="map_canvas_container">
-      <label class="label">Location preview</label>
-      <div class="map_canvas" id="<%= map_id %>"/>
+<%= form.inputs "Location", class: "aageocomplete_wrapper" do %>
+	<% if address != false%>
+  	<%= form.input address, :as => :geocomplete %>
+  <% else %>
+    <li class="input optional">
+      <label class="label">Address</label>
+      <input type="text" class="find_location_input">
     </li>
-    <%= form.input lat, input_html: {data: {geo: "lat"}} if lat != false%>
-    <%= form.input lng, input_html: {data: {geo: "lng"}} if lng != false%>
   <% end %>
-</div>
+  <li class="input optional" id="map_canvas_container">
+    <label class="label">Location preview</label>
+    <div class="map_canvas" id="<%= map_id %>"/>
+  </li>
+  <%= form.input lat, input_html: {data: {geo: "lat"}} if lat != false%>
+  <%= form.input lng, input_html: {data: {geo: "lng"}} if lng != false%>
+<% end %>

--- a/app/views/active_admin/_geocomplete.html.erb
+++ b/app/views/active_admin/_geocomplete.html.erb
@@ -3,16 +3,16 @@
  lng = "longitude" if lng.nil?
  lat = "latitude" if lat.nil?
  https = false if https.nil?
+ map_id = "map_canvas" if map_id.nil?
  %>
 
-<% if https %>
- <script src="https://maps.googleapis.com/maps/api/js?sensor=false&amp;libraries=places"></script>
-<% else %>
-  <script src="http://maps.googleapis.com/maps/api/js?sensor=false&amp;libraries=places"></script>
-<% end %>
+<div class="aageocomplete_wrapper">
+  <% if https %>
+   <script src="https://maps.googleapis.com/maps/api/js?sensor=false&amp;libraries=places"></script>
+  <% else %>
+    <script src="http://maps.googleapis.com/maps/api/js?sensor=false&amp;libraries=places"></script>
+  <% end %>
 
-<%= javascript_include_tag "jquery.geocomplete"%>
-<%= javascript_include_tag "active_admin/geocomplete"%>
   <%= form.inputs "Location" do %>
   	<% if address != false%>
     	<%= form.input address, :as => :geocomplete %>
@@ -24,8 +24,9 @@
     <% end %>
     <li class="input optional" id="map_canvas_container">
       <label class="label">Location preview</label>
-      <div class="map_canvas"/>
+      <div class="map_canvas" id="<%= map_id %>"/>
     </li>
     <%= form.input lat, input_html: {data: {geo: "lat"}} if lat != false%>
     <%= form.input lng, input_html: {data: {geo: "lng"}} if lng != false%>
   <% end %>
+</div>

--- a/lib/active_admin_geocomplete/version.rb
+++ b/lib/active_admin_geocomplete/version.rb
@@ -1,3 +1,3 @@
 module ActiveAdminGeocomplete
-  VERSION = "0.21"
+  VERSION = "0.22"
 end


### PR DESCRIPTION
Previously, if you used the active_admin/geocomplete partial more than once on the one page (i.e. if using nested forms and there was a location for each resource that was nested), the geocomplete instances would clash and if you updated one, the other maps would get updated with the same result.

I've put a class on the form.inputs call, and rejigged the JS so that it does the setup for each instance of the class on the page. Also pulled out hardcoded references to classes and elements for geocomplete, and now they get pulled in relative to the wrapper they are within.

Final result: You can render the partial as many times as you want, as long as you provide a unique ID for the map canvas.
